### PR TITLE
Fix typo "060_porttype_entity." → "060_porttype_entity"

### DIFF
--- a/app/code/community/Ultimate/ModuleCreator/etc/umc_source.xml
+++ b/app/code/community/Ultimate/ModuleCreator/etc/umc_source.xml
@@ -3190,7 +3190,7 @@
                     <sort_order>50</sort_order>
                 </porttype_top>
                 <porttype_entity>
-                    <name>060_porttype_entity.</name>
+                    <name>060_porttype_entity</name>
                     <scope>entity</scope>
                     <depend>
                         <api/>


### PR DESCRIPTION
An instance of the file name "060_porttype_entity" was mis-typed as "060_porttype_entity." (notice the dot at the end) causing a fatal error when saving files.
