### PR TITLE
Add missing interpolation in EntityControllerEavNotTree/060_mass_action

### DIFF
--- a/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/controllers/Adminhtml/Module/EntityControllerEavNotTree/060_mass_action
+++ b/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/controllers/Adminhtml/Module/EntityControllerEavNotTree/060_mass_action
@@ -32,4 +32,3 @@
 
         $this->_redirect('*/*/', array('store'=> $storeId));
     }
-


### PR DESCRIPTION
The request's field name (`'flag_{{attributeCode}}'` instead of just `'flag'`) seems correct in the other cases.
