### PR TITLE
Fix `export*` actions in admin entity controller

### DIFF
--- a/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/controllers/Adminhtml/Module/EntityControllerEavNotTree/050_middle
+++ b/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/controllers/Adminhtml/Module/EntityControllerEavNotTree/050_middle
@@ -142,7 +142,7 @@
     }
 
     /**
-     * export {{entities}} as MsExcel - action
+     * Export {{entities}} in Excel format
      * @access public
      * @return void
      * {{qwertyuiop}}
@@ -154,7 +154,7 @@
         $this->_prepareDownloadResponse($fileName, $content);
     }
     /**
-     * export {{entities}} as xml - action
+     * Export {{entities}} in XML format
      * @access public
      * @return void
      * {{qwertyuiop}}


### PR DESCRIPTION
The bug was only in `EntityEavNotTreeController`:
- exportCsvAction was behaving like exportExcelAction
- exportExcelAction was missing altogether

Now `EntityEavNotTreeController` should conform to the other kinds of Entity.
