### PR TITLE
Spotted a variable name was spelt incorrectly

### DIFF
--- a/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/Helper/Image/Abstract/010_content
+++ b/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/Helper/Image/Abstract/010_content
@@ -125,7 +125,7 @@ abstract class {{Namespace}}_{{Module}}_Helper_Image_Abstract
         if(!$this->_image) {
             $this->_image = '/'.$this->_placeholder;
         }
-        $this->_widht = null;
+        $this->_width = null;
         $this->_height = null;
         $this->_scheduledResize = false;
         $this->_resized = false;


### PR DESCRIPTION
Just a small spelling issue in the image abstract class
