### PR TITLE
Corrected spacing to prevented fatal error in admin grid

### DIFF
--- a/app/code/community/Ultimate/ModuleCreator/Model/Entity/Type/Eav.php
+++ b/app/code/community/Ultimate/ModuleCreator/Model/Entity/Type/Eav.php
@@ -88,8 +88,8 @@ class Ultimate_ModuleCreator_Model_Entity_Type_Eav extends Ultimate_ModuleCreato
             $eol.$this->getPadding(3).'$adminStore'
             .$eol.$this->getPadding(2).');'.$eol;
         $result .= $this->getPadding(2).'if ($store->getId()) {'.$eol;
-        $result .= $this->getPadding(3).    '$collection->joinAttribute(\''.
-            $eol.$this->getPadding(4).$this->getModule()->getNamespace(true).'_'.
+        $result .= $this->getPadding(3).    '$collection->joinAttribute('.
+            $eol.$this->getPadding(4).'\''.$this->getModule()->getNamespace(true).'_'.
             $this->getModule()->getLowerModuleName().'_'.
             $this->getEntity()->getNameSingular().'_'.
             $this->getEntity()->getNameAttributeCode().'\', '.


### PR DESCRIPTION
In the admin grid when you filtered by store scope I was receiving an error report. This is because the sql query was horribly disjointed with new lines and spaces in it.

```
SELECT `e`.*, `at_title`.`value` AS `title`, IF(at_
                namespace_module_page_title.value_id > 0, at_
                namespace_module_page_title.value, at_
                namespace_module_page_title_default.value) AS `
                namespace_module_page_title` FROM `namespace_module_item` AS `e`
 INNER JOIN `namespace_module_item_varchar` AS `at_title` ON (`at_title`.`entity_id` = `e`.`entity_id`) AND (`at_title`.`attribute_id` = '459') AND (`at_title`.`store_id` = 0)
 INNER JOIN `namespace_module_item_varchar` AS `at_
                namespace_module_page_title_default` ON (`at_
                namespace_module_page_title_default`.`entity_id` = `e`.`entity_id`) AND (`at_
                namespace_module_page_title_default`.`attribute_id` = '459') AND `at_
                namespace_module_page_title_default`.`store_id` = 0
 LEFT JOIN `namespace_module_item_varchar` AS `at_
                namespace_module_page_title` ON (`at_
                namespace_module_page_title`.`entity_id` = `e`.`entity_id`) AND (`at_
                namespace_module_page_title`.`attribute_id` = '459') AND (`at_
                namespace_module_page_title`.`store_id` = '2') ORDER BY `e`.`entity_id` ASC LIMIT 20
```

I tracked it down to an error with this generated code.

Currently it generates as:
```
        if ($store->getId()) {
            $collection->joinAttribute('
                namespace_modulename_page_title',
                'namespace_modulename_page/title', 
                'entity_id', 
                null, 
                'inner', 
                $store->getId()
            );
        }
```

With this commit it generates as:
```
        if ($store->getId()) {
            $collection->joinAttribute(
                'namespace_modulename_page_title',
                'namespace_modulename_page/title', 
                'entity_id', 
                null, 
                'inner', 
                $store->getId()
            );
        }
```

It simply removes the `'` from the same line as `joinAttribute('` and brings it down to properly enclose the `namespace_modulename_page_title`.