### PR TITLE
404 Ajax Request for Chooser Widgets #96 fix

### DIFF
--- a/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/Block/Adminhtml/Entity/Widget/Chooser/020_not_tree
+++ b/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/Block/Adminhtml/Entity/Widget/Chooser/020_not_tree
@@ -29,7 +29,7 @@ class {{Namespace}}_{{Module}}_Block_Adminhtml_{{Entity}}_Widget_Chooser extends
     {
         $uniqId = Mage::helper('core')->uniqHash($element->getId());
         $sourceUrl = $this->getUrl(
-            '{{namespace}}_{{module}}/adminhtml_{{module}}_{{entity}}_widget/chooser',
+            '*/{{module}}_{{entity}}_widget/chooser',
             array('uniq_id' => $uniqId)
         );
         $chooser = $this->getLayout()->createBlock('widget/adminhtml_widget_chooser')


### PR DESCRIPTION
Fix for widget bugs throwing 404 error while adding new widget created from the extension