### PR TITLE
Updated Related Entities Loop in Entity Model

### DIFF
--- a/app/code/community/Ultimate/ModuleCreator/Model/Entity.php
+++ b/app/code/community/Ultimate/ModuleCreator/Model/Entity.php
@@ -1463,7 +1463,7 @@ class Ultimate_ModuleCreator_Model_Entity extends Ultimate_ModuleCreator_Model_A
             $content .= $this->getPadding().'<block type="'.$namespace.'_'.$module.'/'.
                 $entityName.'_'.strtolower($entity->getNameSingular()).'_list" name="'.$entityName.
                 '.'.strtolower($entity->getNameSingular()).'_list" as="'.$entityName.'_'.
-                strtolower($this->getNamePlural()).'" template="'.$namespace.'_'.$module.'/'.$entityName.'/'.
+                strtolower($entity->getNamePlural()).'" template="'.$namespace.'_'.$module.'/'.$entityName.'/'.
                 strtolower($entity->getNameSingular()).'/list.phtml" />'.$eol.$this->getPadding(2);
         }
         if ($this->getAllowComment()) {


### PR DESCRIPTION
Updated related entities loop as the variable getting used when defining the "as" value was using the parent entities name and not the related entities name.