### PR TITLE
Missing source_model on multiselect

### DIFF
--- a/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/Helper/Entity/070_eav
+++ b/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/Helper/Entity/070_eav
@@ -28,7 +28,8 @@
     {
         $inputTypes = array(
             'multiselect' => array(
-                'backend_model' => 'eav/entity_attribute_backend_array'
+                'backend_model' => 'eav/entity_attribute_backend_array',
+                'source_model' => 'eav/entity_attribute_source_table'
             ),
             'boolean'     => array(
                 'source_model'  => 'eav/entity_attribute_source_boolean'


### PR DESCRIPTION
The multiselect needs a sourcemodel to be rendered in the form in the backend, if not it throws an error on getAllOptions