### PR TITLE
Fixed incorrect reference to {{qwertyuiopp}}

### DIFF
--- a/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/Block/Entity/List/010_top
+++ b/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/Block/Entity/List/010_top
@@ -5,7 +5,7 @@
  *
  * @category    {{Namespace}}
  * @package     {{Namespace}}_{{Module}}
- * {{qwertyuiop}}
+ * {{qwertyuiopp}}
  */
 class {{Namespace}}_{{Module}}_Block_{{Entity}}_List extends Mage_Core_Block_Template
 {


### PR DESCRIPTION
The class's documentation comment was referencing {{qwertyuiop}}, when it is intended that {{qwertyuiopp}} be used here. Resulting in unfavorable spacing in the final generated source file.