### PR TITLE
Set backend type for multiselect to text

### DIFF
--- a/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/Model/Resource/Eav/Attribute/010_content
+++ b/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/Model/Resource/Eav/Attribute/010_content
@@ -86,6 +86,9 @@ class {{Namespace}}_{{Module}}_Model_Resource_Eav_Attribute extends Mage_Eav_Mod
             case 'image':
                 return 'varchar';
                 break;
+            case 'multiselect':
+                return 'text';
+                break;
             default:
                 return parent::getBackendTypeByInput($type);
             break;


### PR DESCRIPTION
Mage_Eav_Model_Entity_Attribute::getBackendTypeByInput defines multiselect as varchar. But in Ultimate_ModuleCreator_Model_Attribute_Type_Multiselect $_setupType is defined as 'text'. This conflicts when changing the attribute.

To reproduce the bug:
- Create extension with multiselect attribute using UMC.
- In the installed extension, set the attribute to required
- field 'backend_type' in eav_attribute table changes from text to varchar
  Saved values are now gone, and unable to save new values